### PR TITLE
fixing github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,10 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 17
         java-package: jdk+fx
+    - name: Make gradlew executable # this might be a bad practice if there is a better way let me know
+      run: chmod +x ./gradlew
     - name: Run headless test
       uses: GabrielBB/xvfb-action@v1
       with:


### PR DESCRIPTION
This is a way to get the github actions to work. 

I changed java 8 to java 17. 
I then made a work flow to make gradlew executable.
I did this by using a work flow to execute chmod +x ./gradlew.  
This could be a bad practice but it was the most permanent fix.

let me know if you have an questions.